### PR TITLE
elaborates on the build-phases kata

### DIFF
--- a/build-phases/README.md
+++ b/build-phases/README.md
@@ -1,23 +1,44 @@
-# Build phases
+# Gradle Kata: Build phases
 
-## Configuration vs execution time
+This kata explores the three stages of a gradle build:
+- Initialization
+- Configuration
+- Execution
 
-The `build.gradle` script in this exercise contains a property and two tasks:
+## Setup
 
-- `setTheValue` changes the value of `theValue`
-- `printTheValue` prints the value of `theValue`
+Run `source setup.sh`
 
-Predict the outcome of the following commands:
+This will create a new gradle project in the `exercise` directory and add several tasks to `build.gradle`
 
-- `./gradlew printTheValue`
-- `./gradlew setTheValue printTheValue`
+## The task
 
-Run the commands and note the printed values.
+- Examine the `build.gradle` script. It contains a property and two tasks:
+
+    - `setTheValue` changes the value of `theValue`
+    - `printTheValue` prints the value of `theValue`
+
+- Predict the outcome of the following commands:
+
+    - `./gradlew printTheValue`
+    - `./gradlew setTheValue printTheValue`
+
+- Run the commands and note the printed values.
 
 - Q: Did the output match your expectations? If not, what tripped you up?
 
-Make a small change to the `build.gradle` such that:
+- Change `printTheValue` so that the `message` is defined inside the doLast block
+    ```
+    task 'printTheValue' {
+        group 'Value'
+        description 'Prints the value'
 
-- the `printTheValue`-task ends up printing `The value currently is: 200`,
-- when run after the `printTheValue` task and
-- while still using the `theValue` variable
+        doLast {
+            def message = "The value currently is: ${theValue}"
+            println message
+        }
+    }
+    ```
+
+- Run `./gradlew setTheValue printTheValue` again
+- Why is the increased `theValue` printed this time, when it wasn't before?


### PR DESCRIPTION
The kata is now a little more useful as a standalone exercise
since it helps the student to identify the problem.